### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Template6.pm6
+++ b/lib/Template6.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class Template6;
+unit class Template6;
 
 use Template6::Service;
 

--- a/lib/Template6/Context.pm6
+++ b/lib/Template6/Context.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class Template6::Context;
+unit class Template6::Context;
 
 use Template6::Parser;
 use Template6::Stash;

--- a/lib/Template6/Parser.pm6
+++ b/lib/Template6/Parser.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class Template6::Parser;
+unit class Template6::Parser;
 
 has @!keywords = 'eq', 'ne', 'lt', 'gt', 'gte', 'lte';
 has $.context;

--- a/lib/Template6/Provider/File.pm6
+++ b/lib/Template6/Provider/File.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class Template6::Provider::File;
+unit class Template6::Provider::File;
 
 has @.include-path;
 has %.templates;

--- a/lib/Template6/Service.pm6
+++ b/lib/Template6/Service.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class Template6::Service;
+unit class Template6::Service;
 
 use Template6::Context;
 

--- a/lib/Template6/Stash.pm6
+++ b/lib/Template6/Stash.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class Template6::Stash;
+unit class Template6::Stash;
 
 has $.parent is rw;   ## Only used for cloning.
 has %!data;           ## Stores the actual variables.


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.