### PR TITLE
Drop now-illegal "is rw" from array parameter

### DIFF
--- a/lib/Template6/Stash.pm6
+++ b/lib/Template6/Stash.pm6
@@ -9,7 +9,7 @@ method put ($key, $value) {
   %!data{$key} = $value;
 }
 
-method lookup (@query is rw, $data) {
+method lookup (@query, $data) {
   my $element = @query.shift;
   my $found;
   if $data ~~ Hash {


### PR DESCRIPTION
Fixes template6 for newest rakudo.