### PR TITLE
use MONKEY-SEE-NO-EVAL;

### DIFF
--- a/lib/Template6/Parser.pm6
+++ b/lib/Template6/Parser.pm6
@@ -1,4 +1,5 @@
 use v6;
+use MONKEY-SEE-NO-EVAL;
 
 unit class Template6::Parser;
 


### PR DESCRIPTION
EVAL doesn't work anymore unless this pragma is used:
use MONKEY-SEE-NO-EVAL;

Tests are still failing.