### PR TITLE
Adjusted Parser to work on new rakudo versions.

### DIFF
--- a/lib/Template6/Parser.pm6
+++ b/lib/Template6/Parser.pm6
@@ -1,4 +1,5 @@
 use v6;
+use MONKEY-SEE-NO-EVAL;
 
 unit class Template6::Parser;
 
@@ -180,7 +181,7 @@ method action ($statement) {
 
 method compile ($template) {
   my $script = "return sub (\$context) \{\n my \$stash = \$context.stash;\nmy \$output = '';\n";
-  my @segments = $template.split(/\n?'[%' \s* (.*?) \s* '%]'/, :all);
+  my @segments = $template.split(/\n?'[%' \s* (.*?) \s* '%]'/, :v);
   for @segments -> $segment {
     if $segment ~~ Stringy {
       my $string = $segment.subst('}}}}', '\}\}\}\}', :g);


### PR DESCRIPTION
- EVAL $script requires "use MONKEY-SEE-NO-EVAL" now. Added. (Same as #12 )
- In Str.split, :all has been deprecated. The replacement is :v. Fixed.
- Fixes #11 