### PR TITLE
Issue #2: prevent %localdata from being redeclared

### DIFF
--- a/lib/Template6/Parser.pm6
+++ b/lib/Template6/Parser.pm6
@@ -22,7 +22,6 @@ method !parse-template (@defs is copy, $localline)
       $parsing-templates = False;
     }
   }
-
   $return ~= "my \%localdata;\n";
   while @defs.elems >= 3 {
     my $name  = @defs.shift;
@@ -194,7 +193,7 @@ method compile ($template) {
   }
   $script ~= "return \$output;\n\}";
 #  $*ERR.say: "<DEBUG:template>\n$script\n</DEBUG:template>";
-  my $function = EVAL $script;
+  my $function = EVAL $script.subst( / 'my %localdata;' /, '', :nd(2..*) );
   return $function;
 }
 


### PR DESCRIPTION
Ok, so this is probably not the best solution, but it prevents the `my %localdata` from existing more than once in the final `EVAL $script`; It allows us to use `INCLUDE` more than one in our templates:

```html
[% INCLUDE "included" %]
[% INCLUDE "included" %]
```

Thanks,
Sam