### PR TITLE
Correct Invalid template message, added support for "-" on template var names

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,15 @@ Revision history for Template6
 
 {{$NEXT}}
 
+0.16.0 2025-08-03T01:37:50+02:00
+    - Add negation symbol and numeric comparison operators.
+    - Pass all tests.
+    - Fix a bug with the stash lookup in Template6::Parser.
+
+0.15.0 2025-07-18T01:37:50+02:00
+    - Add support for vars using - in their names.
+    - Better user message for unexisting templates.
+
 0.14.0  2023-08-17T02:59:45+02:00
     - making directives that are always for content generation keep the line break
 

--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,5 @@
 {
-  "auth": "zef:raku-community-modules",
+  "auth": "zef:davidromero55",
   "authors": [
     "Timothy Totten"
   ],
@@ -23,7 +23,7 @@
   },
   "resources": [
   ],
-  "source-url": "git://github.com/raku-community-modules/Template6.git",
+  "source-url": "https://github.com/davidromero55/Template6",
   "tags": [
     "TEMPLATE",
     "TT",
@@ -31,5 +31,5 @@
   ],
   "test-depends": [
   ],
-  "version": "0.14.0"
+  "version": "0.15.0"
 }

--- a/META6.json
+++ b/META6.json
@@ -31,5 +31,5 @@
   ],
   "test-depends": [
   ],
-  "version": "0.15.0"
+  "version": "0.16.0"
 }

--- a/README.md
+++ b/README.md
@@ -128,13 +128,17 @@ AUTHOR
 
 Timothy Totten
 
+MANTAINER
+======
+
+David Romero
+
 COPYRIGHT AND LICENSE
 =====================
 
 Copyright 2012 - 2017 Timothy Totten
 
-Copyright 2018 - 2023 Raku Community
+Copyright 2018 - 2025 Raku Community
 
 This library is free software; you can redistribute it and/or modify it
 under the Artistic License 2.0.
-

--- a/lib/Template6/Context.rakumod
+++ b/lib/Template6/Context.rakumod
@@ -91,7 +91,7 @@ method get-template-block(Processable $template-descriptor) {
 
     my $template = self.get-template-text($template-descriptor);
 
-    die "Invalid template '$_'" without $template;
+    die "Invalid template '{$template-descriptor}'" without $template;
     ## If we have a template, store it.
     given $template {
         if $_ !~~ Callable {

--- a/lib/Template6/Parser.rakumod
+++ b/lib/Template6/Parser.rakumod
@@ -157,8 +157,12 @@ sub parse-conditional(@control-stack, Str:D $name, @tokens is copy) {
     @control-stack.unshift('conditional');
     for @tokens -> $token is rw {
         next if $token (elem) @keywords;
-        next if $token ~~ /^ \d+ ['.' \d+]? $/; # TODO probably all numbers are good to go, not just integers
-        $token .= subst(/^ ([\w|\-]+) $/, -> $word { "\$stash.get('$word', :strict)" });
+        # TODO probably all numbers are good to go, not just integers
+        next if $token ~~ /^ \d+ ['.' \d+]? $/;
+        # If the token is a string, we need to resolve it to a stash lookup.
+        next if $token ~~ / \" .*? \" | \' .*? \' /;
+
+        $token .= subst(/^ ([\w|\-|.]+) $/, -> $word { "\$stash.get('$word', :strict)" });
     }
     my $statement = @tokens.join(' ');
     "$name $statement \{\n"

--- a/lib/Template6/Parser.rakumod
+++ b/lib/Template6/Parser.rakumod
@@ -158,7 +158,7 @@ sub parse-conditional(@control-stack, Str:D $name, @tokens is copy) {
     for @tokens -> $token is rw {
         next if $token (elem) @keywords;
         next if $token ~~ /^ \d+ ['.' \d+]? $/; # TODO probably all numbers are good to go, not just integers
-        $token .= subst(/^ (\w+) $/, -> $word { "\$stash.get('$word', :strict)" });
+        $token .= subst(/^ ([\w|\-]+) $/, -> $word { "\$stash.get('$word', :strict)" });
     }
     my $statement = @tokens.join(' ');
     "$name $statement \{\n"

--- a/lib/Template6/Parser.rakumod
+++ b/lib/Template6/Parser.rakumod
@@ -1,6 +1,6 @@
 unit class Template6::Parser;
 
-my @keywords = 'eq', 'ne', 'lt', 'gt', 'gte', 'lte';
+my @keywords = '!','eq', 'ne', 'lt', 'gt', 'gte', 'lte','<', '>', '<=', '>=', '==', '!=';
 subset ControlState of Str where * (elem) <conditional for>;
 
 has $.context;


### PR DESCRIPTION
This patch adds support to add vars using "-" in their names.


[% user-name %]

